### PR TITLE
Added command line options to output a ZX Spectrum attribute block

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ gfx2next [options] &lt;srcfile&gt; [&lt;dstfile&gt;]
 |-pal-rgb332|Output palette in RGB332 (8-bit) format|
 |-pal-bgr222|Output palette in BGR222 (8-bit) format. Bits 7-6 are unused|
 |-pal-zx|Output a ZX Spectrum attribute block for input image|
+|-pal-zx-default|Attribute value to use if only 1 color is detected in attribute|
 |-zx0|Compress all data using zx0|
 |-zx0-screen|Compress screen data using zx0|
 |-zx0-bitmap|Compress bitmap data using zx0|

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ gfx2next [options] &lt;srcfile&gt; [&lt;dstfile&gt;]
 |-pal-none|No raw palette is created|
 |-pal-rgb332|Output palette in RGB332 (8-bit) format|
 |-pal-bgr222|Output palette in BGR222 (8-bit) format. Bits 7-6 are unused|
+|-pal-zx|Output a ZX Spectrum attribute block for input image|
 |-zx0|Compress all data using zx0|
 |-zx0-screen|Compress screen data using zx0|
 |-zx0-bitmap|Compress bitmap data using zx0|

--- a/src/gfx2next.c
+++ b/src/gfx2next.c
@@ -2545,7 +2545,7 @@ static void write_attribs()
 					continue;
 				}
 				// If only one colour, try to find a match in an adjacent cell
-				if (attribCount)
+				if (attribCount >= 2)
 				{
 					uint32_t *prevAttr = &p_attrib[attribCount - 2];
 


### PR DESCRIPTION
Added an option called -pal-zx which instead of outputting a palette, outputs a ZX Spectrum attribute block.
This is useful for converting a png image into a monochrome bitmap and associated attributes for the ZX Spectrum/Next ULA mode.
